### PR TITLE
Fix gzip response processing

### DIFF
--- a/lib/rating_chgk_v2/connection.rb
+++ b/lib/rating_chgk_v2/connection.rb
@@ -19,7 +19,7 @@ module RatingChgkV2
         'Content-Type': 'application/json'
       }
 
-      headers = headers.merge({Authorization: "Bearer #{client.token}"}) if client.token
+      headers = headers.merge({Authorization: "Bearer #{client.token}"}) unless client.token.empty?
 
       {headers: headers, url: BASE_URL}
     end

--- a/lib/rating_chgk_v2/connection.rb
+++ b/lib/rating_chgk_v2/connection.rb
@@ -16,8 +16,7 @@ module RatingChgkV2
       headers = {
         accept: 'application/json',
         user_agent: "rating-chgk-v2 gem/#{RatingChgkV2::VERSION}",
-        'Content-Type': 'application/json',
-        accept_encoding: 'gzip,deflate,br'
+        'Content-Type': 'application/json'
       }
 
       headers = headers.merge({Authorization: "Bearer #{client.token}"}) if client.token


### PR DESCRIPTION
For some reason sending accept_encoding header breaks the parsing of the response after latest API server updates.

Also fixed condition for sending Authorization header (was sending empty as default value is '', not nil).